### PR TITLE
feat: GPS 인증 기능 및 Mission/Place 구조 변경

### DIFF
--- a/src/main/java/avengers/lion/global/exception/ExceptionType.java
+++ b/src/main/java/avengers/lion/global/exception/ExceptionType.java
@@ -27,9 +27,12 @@ public enum ExceptionType {
     // place
     PLACE_FORMAT_ERROR(INTERNAL_SERVER_ERROR,"P001","장소 변환 에러"),
     GOOGLE_API_ERROR(INTERNAL_SERVER_ERROR,"P002", "구글 API 호출 에러"),
+    PLACE_NOT_FOUND(NOT_FOUND,"P003","장소를 찾을 수 없습니다."),
 
     // Mission
     COMPLETED_MISSION_NOT_FOUND(NOT_FOUND, "M001","완료된 미션을 찾을 수 없습니다."),
+    MISSION_NOT_FOUND(NOT_FOUND, "M002", "미션을 찾을 수 없습니다."),
+    GPS_AUTH_FAILED(UNAUTHORIZED,"M0O3", "GPS 인증에 실패하였습니다."),
     
     // Review
     ACCESS_DENIED(FORBIDDEN, "R001", "접근 권한이 없습니다."),

--- a/src/main/java/avengers/lion/mission/controller/MissionController.java
+++ b/src/main/java/avengers/lion/mission/controller/MissionController.java
@@ -2,16 +2,14 @@ package avengers.lion.mission.controller;
 
 import avengers.lion.global.response.ResponseBody;
 import avengers.lion.global.response.ResponseUtil;
+import avengers.lion.mission.dto.GpsAuthenticationRequest;
 import avengers.lion.mission.dto.MissionResponse;
 import avengers.lion.mission.dto.MissionReviewResponse;
 import avengers.lion.mission.service.MissionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -35,17 +33,18 @@ public class MissionController {
     미션에 대한 리뷰 전체조회
      */
     @GetMapping("/{missionId}/reviews")
-    public ResponseEntity<ResponseBody<List<MissionReviewResponse>>> getMissionReview(@PathVariable Long missionId){
+    public ResponseEntity<ResponseBody<List<MissionReviewResponse>>> getMissionReviews(@PathVariable Long missionId){
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(missionService.getMissionReviews(missionId)));
     }
 
-    //TODO : 인증 완료되면 개발하기
     /*
      미션 인증하기  -> gps 인증
      */
-
-    /*
-    사진 인증
-     */
+    @PostMapping("/{missionId}/gps")
+    public ResponseEntity<ResponseBody<Void>> gpsAuthentication(@PathVariable Long missionId, @RequestBody GpsAuthenticationRequest gpsAuthenticationRequest){
+        missionService.GpsAuthentication(missionId, gpsAuthenticationRequest);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+    //TODO: 사진 인증  SSE 구현
 
 }

--- a/src/main/java/avengers/lion/mission/domain/Mission.java
+++ b/src/main/java/avengers/lion/mission/domain/Mission.java
@@ -2,6 +2,7 @@ package avengers.lion.mission.domain;
 
 import avengers.lion.global.base.BaseEntity;
 import avengers.lion.place.domain.Place;
+import avengers.lion.place.domain.PlaceCategory;
 import avengers.lion.review.domain.Review;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.DecimalMax;
@@ -34,6 +35,9 @@ public class Mission extends BaseEntity {
     @Column(name = "description", nullable = false)
     private String description;
 
+    @Column(name = "place_category", nullable = false)
+    private PlaceCategory placeCategory;
+
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private MissionStatus status;
@@ -41,42 +45,37 @@ public class Mission extends BaseEntity {
     @Column(name = "address", nullable = false)
     private String address;
 
-    @Column(name = "latitude", precision = 10, scale = 8)
-    @DecimalMin(value = "-90.0")
-    @DecimalMax(value = "90.0")
-    private BigDecimal latitude;
+    @Column(name = "latitude", columnDefinition = "DECIMAL(10,8)")
+    private Double latitude;
 
-    @Column(name = "longitude", precision = 11, scale = 8)
-    @DecimalMin(value = "-180.0")
-    @DecimalMax(value = "180.0")
-    private BigDecimal longitude;
-
-    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
-    private List<Review> reviews = new ArrayList<>();
+    @Column(name = "longitude", columnDefinition = "DECIMAL(11,8)")
+    private Double longitude;
 
     @ManyToOne
     @JoinColumn(name = "mission_batch_id", nullable = false)
     private MissionBatches missionBatches;
 
-    public Mission(Long id, String placeName, String title, String address, String description, MissionStatus status, BigDecimal latitude, BigDecimal longitude, MissionBatches missionBatches) {
+    public Mission(Long id, String placeName, String title, String address, String description, PlaceCategory placeCategory, MissionStatus status, Double latitude, Double longitude, MissionBatches missionBatches) {
         this.id = id;
         this.placeName = placeName;
         this.title = title;
         this.address = address;
         this.description = description;
+        this.placeCategory = placeCategory;
         this.status = status;
         this.latitude = latitude;
         this.longitude = longitude;
         this.missionBatches = missionBatches;
     }
 
-    public static Mission createFromPlace(Place place, String title, String description, MissionBatches batch) {
+    public static Mission createFromPlace(Place place, String title, PlaceCategory placeCategory, String description, MissionBatches batch) {
         return new Mission(
             null,
             place.getName(),
             title,
             place.getAddress(),
             description,
+            placeCategory,
             MissionStatus.ACTIVE,
             place.getLatitude(),
             place.getLongitude(),

--- a/src/main/java/avengers/lion/mission/dto/GpsAuthenticationRequest.java
+++ b/src/main/java/avengers/lion/mission/dto/GpsAuthenticationRequest.java
@@ -1,0 +1,4 @@
+package avengers.lion.mission.dto;
+
+public record GpsAuthenticationRequest(Double latitude, Double longitude) {
+}

--- a/src/main/java/avengers/lion/mission/dto/MissionResponse.java
+++ b/src/main/java/avengers/lion/mission/dto/MissionResponse.java
@@ -1,10 +1,10 @@
 package avengers.lion.mission.dto;
 
 import avengers.lion.mission.domain.Mission;
+import avengers.lion.place.domain.PlaceCategory;
 
-import java.math.BigDecimal;
 
-public record MissionResponse(Long missionId, String placeName, String title, String description, BigDecimal latitude, BigDecimal longitude) {
+public record MissionResponse(Long missionId, String placeName, String title, String description, Double latitude, Double longitude, PlaceCategory placeCategory) {
 
     public static MissionResponse from(Mission mission){
         return new MissionResponse(
@@ -13,6 +13,8 @@ public record MissionResponse(Long missionId, String placeName, String title, St
                 mission.getTitle(),
                 mission.getDescription(),
                 mission.getLatitude(),
-                mission.getLongitude());
-    }
+                mission.getLongitude(),
+                mission.getPlaceCategory()
+        );
+    };
 }

--- a/src/main/java/avengers/lion/mission/service/MissionScheduler.java
+++ b/src/main/java/avengers/lion/mission/service/MissionScheduler.java
@@ -1,5 +1,7 @@
 package avengers.lion.mission.service;
 
+import avengers.lion.global.exception.BusinessException;
+import avengers.lion.global.exception.ExceptionType;
 import avengers.lion.mission.domain.BatchStatus;
 import avengers.lion.mission.domain.Mission;
 import avengers.lion.mission.domain.MissionBatches;
@@ -46,7 +48,8 @@ public class MissionScheduler implements Job {
         for(PlaceCategory category : PlaceCategory.values()){
             // 현재일 기준으로, 20일 전에 조회된 데이터는 제외
             LocalDateTime now = LocalDate.now().minusDays(20).atStartOfDay();
-            Place place = placeRepository.findByCategoryWithSelectionCriteria(category,now);
+            Place place = placeRepository.findByCategoryWithSelectionCriteria(category,now)
+                    .orElseThrow(()->new BusinessException(ExceptionType.PLACE_NOT_FOUND));
             // 마지막으로 조회된 날짜, 카운트 개수 설정
             place.updateSelectionInfo();
             places.add(place);

--- a/src/main/java/avengers/lion/mission/service/MissionService.java
+++ b/src/main/java/avengers/lion/mission/service/MissionService.java
@@ -1,12 +1,17 @@
 package avengers.lion.mission.service;
 
+import avengers.lion.global.exception.BusinessException;
+import avengers.lion.global.exception.ExceptionType;
 import avengers.lion.mission.domain.Mission;
 import avengers.lion.mission.domain.MissionStatus;
+import avengers.lion.mission.dto.GpsAuthenticationRequest;
 import avengers.lion.mission.dto.MissionResponse;
 import avengers.lion.mission.dto.MissionReviewResponse;
+import avengers.lion.mission.repository.CompletedMissionRepository;
 import avengers.lion.mission.repository.MissionRepository;
 import avengers.lion.review.domain.Review;
 import avengers.lion.review.repository.ReviewRepository;
+import com.cloudinary.Cloudinary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,8 +21,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MissionService {
 
+    private static final double THRESHOLD_METERS = 100.0;
+
     private final MissionRepository missionRepository;
     private final ReviewRepository reviewRepository;
+    private final CompletedMissionRepository completedMissionRepository;
+    private final Cloudinary cloudinary;
+
     /*
     미션 전체조회
      */
@@ -37,5 +47,32 @@ public class MissionService {
         return reviews.stream()
                 .map(MissionReviewResponse::from)
                 .toList();
+    }
+
+    /*
+    미션 GPS 인증
+     */
+    public void GpsAuthentication(Long missionId, GpsAuthenticationRequest gpsAuthenticationRequest) {
+        double userLat = gpsAuthenticationRequest.latitude();
+        double userLng = gpsAuthenticationRequest.longitude();
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(()->new BusinessException(ExceptionType.MISSION_NOT_FOUND));
+        double dist = calcDistanceMeters(userLat, userLng, mission.getLatitude(), mission.getLongitude());
+        if(dist > THRESHOLD_METERS)
+            throw new BusinessException(ExceptionType.GPS_AUTH_FAILED);
+    }
+
+    private double calcDistanceMeters(
+            double lat1, double lng1, double lat2, double lng2
+    ) {
+        double r = 6_371_000; // 지구 반지름(m)
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat/2)*Math.sin(dLat/2)
+                + Math.cos(Math.toRadians(lat1))
+                * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng/2)*Math.sin(dLng/2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        return r * c;
     }
 }

--- a/src/main/java/avengers/lion/place/domain/Place.java
+++ b/src/main/java/avengers/lion/place/domain/Place.java
@@ -37,21 +37,16 @@ public class Place {
 
     private String address;
 
-    @Column(name = "latitude", precision = 10, scale = 8)
-    @DecimalMin(value = "-90.0")
-    @DecimalMax(value = "90.0")
-    private BigDecimal latitude;
+    @Column(name = "latitude", columnDefinition = "DECIMAL(10,8)")
+    private Double latitude;
 
-    @Column(name = "longitude", precision = 11, scale = 8)
-    @DecimalMin(value = "-180.0")
-    @DecimalMax(value = "180.0")
-
-    private BigDecimal longitude;
+    @Column(name = "longitude", columnDefinition = "DECIMAL(11,8)")
+    private Double longitude;
 
     @Column(name = "selection_count", nullable = false, columnDefinition = "INT DEFAULT 0")
     private int selectionCount=0;
 
-    public void setGeocodingResult(BigDecimal latitude, BigDecimal longitude){
+    public void setGeocodingResult(Double latitude, Double longitude){
         this.latitude = latitude;
         this.longitude = longitude;
     }

--- a/src/main/java/avengers/lion/place/repository/PlaceRepository.java
+++ b/src/main/java/avengers/lion/place/repository/PlaceRepository.java
@@ -4,11 +4,10 @@ import avengers.lion.place.domain.Place;
 import avengers.lion.place.domain.PlaceCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
@@ -16,5 +15,5 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query("SELECT p FROM Place p WHERE p.category = :category " +
         "AND (p.lastSearchDate IS NULL OR p.lastSearchDate < :cutoffDate) " +
         "ORDER BY p.selectionCount ASC, RAND() LIMIT 1")
-    Place findByCategoryWithSelectionCriteria(PlaceCategory category, LocalDateTime cutoffDate);
+    Optional<Place> findByCategoryWithSelectionCriteria(PlaceCategory category, LocalDateTime cutoffDate);
 }

--- a/src/main/java/avengers/lion/place/service/PlaceScheduler.java
+++ b/src/main/java/avengers/lion/place/service/PlaceScheduler.java
@@ -30,8 +30,8 @@ public class PlaceScheduler implements Job {
         List<Place> places = placeRepository.findAll();
         for(Place place : places) {
             GeocodeInfo info = placeService.geocode(place.getName());
-            BigDecimal lat = BigDecimal.valueOf(info.lat());
-            BigDecimal lng = BigDecimal.valueOf(info.lng());
+            Double lat = info.lat();
+            Double lng = info.lng();
             place.setGeocodingResult(lat, lng);
             placeRepository.save(place);
         }


### PR DESCRIPTION

## 🔍 PR 내용 요약  
- 미션 수행 시 GPS 인증 기능 구현  
- 위도·경도 타입을 `BigDecimal` → `Double`로 변경  
- 미션 조회 시 `PlaceCategory` 필드 포함  
- 장소 탐색 로직 개선 및 예외 처리 추가  


## 💻 주요 변경 사항  

### 1. Mission
- `latitude`, `longitude` 필드를 `Double`로 변경 (`DECIMAL(10,8)` / `DECIMAL(11,8)`)
- `placeCategory` 필드 추가  
- `createFromPlace` 메서드 시그니처 변경 (카테고리 인자 추가)

### 2. Place
- `latitude`, `longitude` 타입 변경 (`BigDecimal` → `Double`)

### 3. GPS 인증 기능
- `GpsAuthenticationRequest` DTO 추가
- `MissionService`에 `GpsAuthentication` 메서드 추가  
  - 허용 거리 `100m` 이내일 경우 인증 성공
  - 거리 계산 메서드(`calcDistanceMeters`) 구현 (Haversine formula)