### PR TITLE
feat : 날씨 조회 api 기능

### DIFF
--- a/src/main/java/avengers/lion/global/config/RedisConfig.java
+++ b/src/main/java/avengers/lion/global/config/RedisConfig.java
@@ -5,7 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableRedisRepositories
 @Configuration
@@ -17,7 +20,21 @@ public class RedisConfig {
     private int redisPort;
 
     @Bean
+    // Redis 서버 연결을 관리하는 객체
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    // Redis에 데이터를 저장/조회하는 클래스 -> 키 : String, 값 : Object
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory cf) {
+        // 새로운 RedisTemplate 인스턴스 생성
+        RedisTemplate<String, Object> t = new RedisTemplate<>();
+        t.setConnectionFactory(cf);
+        // 키 직렬화 방식 -> Redis는 네트워크로 데이터를 주고 받을 때 바이트로 처리하기 때문에 String을 바이트 배열로 변환하는 객체 사용
+        t.setKeySerializer(new StringRedisSerializer());
+        // 값 직렬화 방식
+        t.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return t;
     }
 }

--- a/src/main/java/avengers/lion/global/exception/ExceptionType.java
+++ b/src/main/java/avengers/lion/global/exception/ExceptionType.java
@@ -52,7 +52,10 @@ public enum ExceptionType {
     INVALID_ORDER_STATUS(BAD_REQUEST, "O002", "취소할 수 없는 주문 상태입니다."),
 
     // Wallet
-    PRICE_IS_POSITIVE(BAD_REQUEST, "W001", "가격은 음수여야 합니다.");
+    PRICE_IS_POSITIVE(BAD_REQUEST, "W001", "가격은 음수여야 합니다."),
+
+    // Weather
+    WEATHER_API_ERROR(INTERNAL_SERVER_ERROR,"WE001","OpenWeather API 호출 에러");
 
 
 

--- a/src/main/java/avengers/lion/weather/api/WeatherApi.java
+++ b/src/main/java/avengers/lion/weather/api/WeatherApi.java
@@ -1,0 +1,57 @@
+package avengers.lion.weather.api;
+
+import avengers.lion.global.config.swagger.SwaggerApiFailedResponse;
+import avengers.lion.global.config.swagger.SwaggerApiResponses;
+import avengers.lion.global.config.swagger.SwaggerApiSuccessResponse;
+import avengers.lion.global.exception.ExceptionType;
+import avengers.lion.global.response.ResponseBody;
+import avengers.lion.weather.dto.WeatherBasic;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Tag(name = "날씨 API", description = "OpenWeather One Call 기반 구미 지역(기본 좌표) 날씨 조회")
+public interface WeatherApi {
+
+    @Operation(
+            summary = "날씨 기본 정보 조회",
+            description = """
+            Redis 캐시(KST 매 정시)에 저장된 날씨 데이터를 반환합니다.
+            응답 구조:
+            - data.current: 현재 기온/아이콘/오늘 최고·최저
+            - data.hourly48: 48시간 (KST '오전/오후 h시' 포맷), 시간별 기온/아이콘
+            - data.next5Days: 오늘 제외 5일, 요일, 일최고/일최저/강수확률/아이콘
+            
+            아이콘 사용 방법:
+            - 각 기온 데이터에는 `icon` 코드가 포함됩니다.
+            - 해당 코드를 아래 URL에 치환하여 이미지로 사용합니다:
+            https://openweathermap.org/img/wn/{icon}@2x.png
+            (예: icon 값이 `10d`라면 → `https://openweathermap.org/img/wn/10d@2x.png`)
+            """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                    schema = @Schema(implementation = WeatherBasic.class)
+                    )
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = WeatherBasic.class,
+                    description = "날씨 데이터 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(
+                            value = ExceptionType.WEATHER_API_ERROR,
+                            description = "OpenWeather API 호출 실패 또는 응답 파싱 오류"
+                    ),
+            }
+    )
+    @PreAuthorize("hasAuthority('ROLE_USER')")
+    ResponseEntity<ResponseBody<WeatherBasic>> getWeather();
+}

--- a/src/main/java/avengers/lion/weather/controller/WeatherController.java
+++ b/src/main/java/avengers/lion/weather/controller/WeatherController.java
@@ -7,6 +7,7 @@ import avengers.lion.weather.dto.WeatherBasic;
 import avengers.lion.weather.service.WeatherService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +19,7 @@ public class WeatherController implements WeatherApi {
     private final WeatherService weatherService;
 
     @PostMapping
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<ResponseBody<WeatherBasic>> getWeather(){
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(weatherService.oneCall()));
     }

--- a/src/main/java/avengers/lion/weather/controller/WeatherController.java
+++ b/src/main/java/avengers/lion/weather/controller/WeatherController.java
@@ -8,9 +8,7 @@ import avengers.lion.weather.service.WeatherService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class WeatherController implements WeatherApi {
     private final WeatherService weatherService;
 
-    @PostMapping
+    @GetMapping
     @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<ResponseBody<WeatherBasic>> getWeather(){
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(weatherService.oneCall()));

--- a/src/main/java/avengers/lion/weather/controller/WeatherController.java
+++ b/src/main/java/avengers/lion/weather/controller/WeatherController.java
@@ -1,0 +1,24 @@
+package avengers.lion.weather.controller;
+
+import avengers.lion.global.response.ResponseBody;
+import avengers.lion.global.response.ResponseUtil;
+import avengers.lion.weather.api.WeatherApi;
+import avengers.lion.weather.dto.WeatherBasic;
+import avengers.lion.weather.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/weather")
+public class WeatherController implements WeatherApi {
+    private final WeatherService weatherService;
+
+    @PostMapping
+    public ResponseEntity<ResponseBody<WeatherBasic>> getWeather(){
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(weatherService.oneCall()));
+    }
+}

--- a/src/main/java/avengers/lion/weather/dto/OpenWeatherDto.java
+++ b/src/main/java/avengers/lion/weather/dto/OpenWeatherDto.java
@@ -1,0 +1,15 @@
+package avengers.lion.weather.dto;// weather/api/OneCallDto.java
+
+
+import java.util.List;
+
+public record OpenWeatherDto(
+        Current current, List<Hourly> hourly, List<Daily> daily
+) {
+    public record Current(Double temp, List<Weather> weather) {}
+    public record Hourly(Long dt, Double temp, List<Weather> weather) {}
+    public record Daily(Long dt, Temp temp, List<Weather> weather, Double pop) {
+        public record Temp(Double min, Double max) {}
+    }
+    public record Weather(String description, String icon) {}
+}

--- a/src/main/java/avengers/lion/weather/dto/WeatherBasic.java
+++ b/src/main/java/avengers/lion/weather/dto/WeatherBasic.java
@@ -1,0 +1,94 @@
+package avengers.lion.weather.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "날씨 기본 응답 뷰 (현재/48시간/향후 5일)")
+public record WeatherBasic(
+
+        @Schema(
+                description = "현재 날씨",
+                example = """
+                { "temp": 25.8, "icon": "10d", "todayMax": 26.64, "todayMin": 22.64 }
+                """
+        )
+        Now current,
+
+        @ArraySchema(
+                schema = @Schema(implementation = Hour.class),
+                arraySchema = @Schema(
+                        description = "48시간 시계열 (KST '오전/오후 h시' 포맷)",
+                        example = """
+                        [
+                          { "time": "오후 3시", "temp": 25.6, "icon": "04d" },
+                          { "time": "오후 4시", "temp": 25.8, "icon": "10d" },
+                          { "time": "오후 5시", "temp": 25.48, "icon": "10d" }
+                        ]
+                        """
+                )
+        )
+        List<Hour> hourly48,
+
+        @ArraySchema(
+                schema = @Schema(implementation = Day.class),
+                arraySchema = @Schema(
+                        description = "오늘 제외 5일 요약",
+                        example = """
+                        [
+                          { "dayOfWeek": "일", "tempMax": 31.53, "tempMin": 20.42, "rainProbability": 0.0, "icon": "04d" },
+                          { "dayOfWeek": "월", "tempMax": 29.57, "tempMin": 20.49, "rainProbability": 0.0, "icon": "04d" },
+                          { "dayOfWeek": "화", "tempMax": 24.43, "tempMin": 22.5, "rainProbability": 1.0, "icon": "10d" },
+                          { "dayOfWeek": "수", "tempMax": 23.74, "tempMin": 22.79, "rainProbability": 1.0, "icon": "10d" },
+                          { "dayOfWeek": "목", "tempMax": 29.86, "tempMin": 23.14, "rainProbability": 0.36, "icon": "10d" }
+                        ]
+                        """
+                )
+        )
+        List<Day> next5Days
+
+) {
+
+    @Schema(description = "현재 날씨")
+    public record Now(
+            @Schema(description = "현재 기온(°C)", example = "25.8")
+            Double temp,
+            @Schema(description = "OpenWeather 아이콘 코드", example = "10d")
+            String icon,
+            @Schema(description = "오늘 최고 기온(°C)", example = "26.64")
+            Double todayMax,
+            @Schema(description = "오늘 최저 기온(°C)", example = "22.64")
+            Double todayMin
+    ) {}
+
+    @Schema(description = "시간대별 날씨")
+    public record Hour(
+            @Schema(description = "시각 (KST, '오전/오후 h시')", example = "오후 3시")
+            String time,
+            @Schema(description = "기온(°C)", example = "25.6")
+            Double temp,
+            @Schema(description = "OpenWeather 아이콘 코드", example = "04d")
+            String icon
+    ) {
+        // (옵션) 필요 시 시간대 최고/최저 확장용
+        public record Temp(
+                @Schema(example = "26.6") Double max,
+                @Schema(example = "22.6") Double min
+        ) {}
+    }
+
+    @Schema(description = "일자별 요약")
+    public record Day(
+            @Schema(description = "요일 (짧은 형식)", example = "일")
+            String dayOfWeek,
+            @Schema(description = "일 최고 기온(°C)", example = "31.53")
+            Double tempMax,
+            @Schema(description = "일 최저 기온(°C)", example = "20.42")
+            Double tempMin,
+            @Schema(description = "강수 확률(0.0~1.0)", example = "0.0")
+            Double rainProbability,
+            @Schema(description = "OpenWeather 아이콘 코드", example = "04d")
+            String icon
+    ) {}
+}

--- a/src/main/java/avengers/lion/weather/service/WeatherService.java
+++ b/src/main/java/avengers/lion/weather/service/WeatherService.java
@@ -1,0 +1,132 @@
+package avengers.lion.weather.service;
+
+import avengers.lion.global.exception.BusinessException;
+import avengers.lion.global.exception.ExceptionType;
+import avengers.lion.weather.dto.OpenWeatherDto;
+import avengers.lion.weather.dto.WeatherBasic;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.*;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherService {
+
+    private final RestTemplate rest;
+    private final RedisTemplate<String, Object> redis;
+
+    @Value("${openweather.api.base-url}")
+    String baseUrl;
+    @Value("${openweather.api.key}")
+    String apiKey;
+    @Value("${openweather.api.lang}")
+    String lang;
+    @Value("${openweather.api.units}")
+    String units;
+    @Value("${openweather.api.default-lat}")
+    double lat;
+    @Value("${openweather.api.default-lon}")
+    double lon;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter HOUR_FMT = DateTimeFormatter.ofPattern("a h시", Locale.KOREAN);
+
+    private String cacheKey() {
+        ZonedDateTime hour = ZonedDateTime.now(KST).truncatedTo(ChronoUnit.HOURS);
+        return "weather:gumi:basic:" +hour.toEpochSecond();
+    }
+    private Duration ttlUntilNextHour() {
+        ZonedDateTime now = ZonedDateTime.now(KST);
+        return Duration.between(now, now.truncatedTo(ChronoUnit.HOURS).plusHours(1)).plusSeconds(5);
+    }
+
+    public WeatherBasic oneCall() {
+        // redis에서 데이터를 꺼낸다
+        // redis에서 데이터가 없으면
+        String key = cacheKey();
+        Object hit = redis.opsForValue().get(key);
+        if(hit instanceof WeatherBasic cached) {
+            log.info("날씨 데이터 캐시");
+            return cached;
+        }
+        log.info("날씨 데이터 캐시안됨");
+        OpenWeatherDto dto =  requestOpenWeather();
+        OpenWeatherDto.Current current = dto.current();
+        List<OpenWeatherDto.Hourly> hourly = dto.hourly();
+        List<OpenWeatherDto.Daily> daily = dto.daily();
+
+        // 현재
+        WeatherBasic.Now now = new WeatherBasic.Now(
+                current.temp(),
+                current.weather().getFirst().icon(),
+                daily.getFirst().temp().max(),
+                daily.getFirst().temp().min());
+
+        // 48시간
+        List<WeatherBasic.Hour> hourList = hourly.stream()
+                .map(hour -> {
+                    ZonedDateTime kstTime = Instant.ofEpochSecond(hour.dt())
+                            .atZone(ZoneId.of("Asia/Seoul"));
+
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("a h시", Locale.KOREAN);
+                    String formattedTime = kstTime.format(formatter);
+                    return new WeatherBasic.Hour(formattedTime, hour.temp(), hour.weather().getFirst().icon());
+                })
+                .toList();
+
+        // 오늘 제외
+        List<WeatherBasic.Day> dayList = daily.stream()
+                .skip(1)
+                .limit(5)
+                .map(day -> {
+                    ZonedDateTime kstTime = Instant.ofEpochSecond(day.dt()).atZone(ZoneId.of("Asia/Seoul"));
+                    String dayOfWeek = kstTime.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN)+"요일";
+                    return new WeatherBasic.Day(dayOfWeek,
+                            day.temp().max(),
+                            day.temp().min(),
+                            day.pop(),
+                            day.weather().getFirst().icon()
+                    );
+                })
+                .toList();
+        WeatherBasic view = new WeatherBasic(now, hourList, dayList);
+        redis.opsForValue().set(key, view, ttlUntilNextHour());
+        return view;
+    }
+    public OpenWeatherDto requestOpenWeather() {
+        URI uri = UriComponentsBuilder.fromUriString(baseUrl + "/data/3.0/onecall")
+                .queryParam("lat", lat)
+                .queryParam("lon", lon)
+                .queryParam("appid", apiKey)
+                .queryParam("lang", lang)
+                .queryParam("units", units)
+                .queryParam("exclude", "minutely,alerts")
+                .build()
+                .toUri();
+        log.info("onecall uri = {}", uri);
+        try{
+            return rest.getForObject(uri, OpenWeatherDto.class);
+        } catch(HttpClientErrorException | HttpServerErrorException | UnknownContentTypeException | ResourceAccessException e) {
+            log.error("OpenWeather API 호출 실패: {}", e.getMessage());
+            throw new BusinessException(ExceptionType.WEATHER_API_ERROR);
+        }
+
+    }
+}


### PR DESCRIPTION
## What is this PR? 🔍
구미 지역의 실시간/단기/중기 날씨 정보를 OpenWeather One Call API 기반으로 조회하는 기능을 구현했습니다.  
Redis 캐시를 활용하여 매 정시(KST)마다 날씨 데이터를 저장/조회하여 API 호출 부하를 줄입니다.

## Changes 💻
- **Weather API 엔드포인트 추가**
  - `/api/v1/weather` (POST) : 현재, 48시간, 향후 5일 날씨 조회
  - `ROLE_USER` 권한 필요
- **WeatherBasic DTO 작성**
  - 현재 날씨, 시간별 날씨(48시간), 일별 날씨(5일) 정보 구조화
  - Swagger 예시 데이터 및 설명 추가
- **OpenWeatherDto 작성**
  - OpenWeather One Call API 응답 매핑용 DTO
- **WeatherService 구현**
  - Redis 캐시 키 생성 및 TTL 설정 (다음 정시 + 5초)
  - 캐시 미스 시 OpenWeather API 호출
  - 시간 포맷(KST, 오전/오후 h시) 변환 처리
  - 요일 표기(짧은 형식 + '요일')
- **예외 처리**
  - `WEATHER_API_ERROR` 예외 코드 추가 (API 호출 실패/파싱 오류 시)
- **RedisConfig 직렬화 설정**
  - Key: `StringRedisSerializer`
  - Value: `GenericJackson2JsonRedisSerializer`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 구미 지역의 현재 날씨, 48시간 시간별 예보, 5일간 일별 요약 정보를 제공하는 날씨 API 엔드포인트가 추가되었습니다.
  * 날씨 데이터는 OpenWeather API로부터 받아오며, 응답 속도 향상을 위해 Redis 캐시를 활용합니다.
  * API 응답에 오류 발생 시 상세한 에러 메시지가 제공됩니다.

* **기타**
  * Redis 연동 설정이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->