### PR TITLE
feat : 랜덤 프로필 이미지 & 마이페이지 닉네임 변경 기능

### DIFF
--- a/src/main/java/avengers/lion/auth/api/AuthApi.java
+++ b/src/main/java/avengers/lion/auth/api/AuthApi.java
@@ -26,7 +26,7 @@ public interface AuthApi {
     @Operation(
             summary = "회원가입",
             description = """
-            이메일, 닉네임, 비밀번호, 프로필 이미지 URL을 제공하여 새로운 사용자를 등록합니다.
+            이메일, 닉네임, 비밀번호를 제공하여 새로운 사용자를 등록합니다.
             이메일 중복 시 예외가 발생합니다.
             """
     )

--- a/src/main/java/avengers/lion/auth/dto/RegisterRequest.java
+++ b/src/main/java/avengers/lion/auth/dto/RegisterRequest.java
@@ -17,9 +17,6 @@ public record RegisterRequest(
 
         @Schema(description = "비밀번호", example = "password1234")
         @NotBlank(message = "비밀번호는 필수입니다")
-        String password,
-
-        @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.png")
-        String profileImageUrl
+        String password
 ) {
 }

--- a/src/main/java/avengers/lion/auth/service/AuthService.java
+++ b/src/main/java/avengers/lion/auth/service/AuthService.java
@@ -20,6 +20,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Random;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -29,6 +32,15 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final AuthenticationManager authenticationManager;
+    private static final List<String> PROFILE_IMAGES = List.of(
+            "https://res.cloudinary.com/do5bj2fie/image/upload/v1755264379/6.%ED%86%A0%EB%81%BC_y5lqzd.png",
+            "https://res.cloudinary.com/do5bj2fie/image/upload/v1755264379/5.%EC%98%A4%EB%A6%AC_ybspmo.png",
+            "https://res.cloudinary.com/do5bj2fie/image/upload/v1755264378/4.%EA%B3%A0%EC%96%91%EC%9D%B4_xlhylh.png",
+            "https://res.cloudinary.com/do5bj2fie/image/upload/v1755264378/3.%EA%B3%A0%EC%8A%B4%EB%8F%84%EC%B9%98_l8mcp9.png",
+            "https://res.cloudinary.com/do5bj2fie/image/upload/v1755264378/1.%EA%B0%95%EC%95%84%EC%A7%80_jtg9re.png",
+            "https://res.cloudinary.com/do5bj2fie/image/upload/v1755264378/2.%EA%B1%B0%EB%B6%81%EC%9D%B4_szcdbc.png"
+    );
+
 
     public void signUp(RegisterRequest request) {
         // 이메일 중복 검사
@@ -42,10 +54,10 @@ public class AuthService {
                 .nickname(request.nickname())
                 .password(passwordEncoder.encode(request.password()))
                 .role(MemberRole.ROLE_USER)
-                .profileImageUrl(request.profileImageUrl())
+                .profileImageUrl(getRandomProfileImage())
                 .build();
 
-        Member savedMember = memberRepository.save(member);
+        memberRepository.save(member);
     }
 
     public LoginResponse login(LoginRequest request) {
@@ -86,5 +98,9 @@ public class AuthService {
         String accessToken = generateAccessToken(member);
 
         return new LoginWithTokenResponse(loginResponse, accessToken);
+    }
+    private String getRandomProfileImage(){
+        Random random = new Random();
+        return PROFILE_IMAGES.get(random.nextInt(PROFILE_IMAGES.size()));
     }
 }

--- a/src/main/java/avengers/lion/global/exception/ExceptionType.java
+++ b/src/main/java/avengers/lion/global/exception/ExceptionType.java
@@ -20,6 +20,7 @@ public enum ExceptionType {
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
     INSUFFICIENT_POINT(NOT_FOUND,"U002", "아이템 교환에 필요한 포인트가 부족합니다."),
     INVALID_PASSWORD(UNAUTHORIZED,"M003","비밀번호가 일치하지 않습니다."),
+    NICKNAME_ALREADY_EXISTS(CONFLICT,"M004","이미 등록된 닉네임입니다."),
 
 
 

--- a/src/main/java/avengers/lion/member/api/MemberApi.java
+++ b/src/main/java/avengers/lion/member/api/MemberApi.java
@@ -1,31 +1,36 @@
 package avengers.lion.member.api;
 
-import avengers.lion.global.exception.ExceptionType;
-import avengers.lion.global.response.ResponseBody;
-import avengers.lion.member.dto.MyProfileResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import avengers.lion.global.config.swagger.SwaggerApiFailedResponse;
 import avengers.lion.global.config.swagger.SwaggerApiResponses;
 import avengers.lion.global.config.swagger.SwaggerApiSuccessResponse;
+import avengers.lion.global.exception.ExceptionType;
+import avengers.lion.global.response.ResponseBody;
+import avengers.lion.member.dto.MyProfileResponse;
+import avengers.lion.member.dto.UpdateNicknameRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 
-@Tag(name = "회원 API", description = "회원 정보 조회 API")
+@Tag(name = "회원 API", description = "마이프로필 조회/수정 API")
 public interface MemberApi {
 
     @Operation(
             summary = "내 프로필 조회",
             description = """
-            로그인된 사용자의 프로필 정보를 조회합니다.<br>
-            닉네임, 이메일, 프로필 이미지 URL 등 개인 정보를 반환합니다.
-            """, security = { @SecurityRequirement(name = "JWT") }
+                로그인된 사용자의 프로필 정보를 조회합니다.<br>
+                닉네임, 이메일, 프로필 이미지 URL, 포인트 등 개인 정보를 반환합니다.
+                """,
+            security = { @SecurityRequirement(name = "JWT") }
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = MyProfileResponse.class)))
     @SwaggerApiResponses(
@@ -40,7 +45,7 @@ public interface MemberApi {
                     ),
                     @SwaggerApiFailedResponse(
                             value = ExceptionType.ACCESS_DENIED,
-                            description = "본인의 완료된 미션에 대해서만 리뷰를 작성할 수 있습니다."
+                            description = "접근 권한이 없습니다."
                     )
             }
     )
@@ -48,5 +53,52 @@ public interface MemberApi {
     @GetMapping("/api/v1/members/my-profile")
     ResponseEntity<ResponseBody<MyProfileResponse>> getMyProfile(
             @AuthenticationPrincipal Long memberId
+    );
+
+    @Operation(
+            summary = "내 프로필 수정(닉네임)",
+            description = """
+                로그인된 사용자의 닉네임을 수정합니다.<br>
+                닉네임 중복 여부를 검사하며, 성공 시 본문 없이 성공 응답을 반환합니다.
+                """,
+            security = { @SecurityRequirement(name = "JWT") }
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = Void.class,
+                    description = "닉네임이 성공적으로 변경되었습니다."
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(
+                            value = ExceptionType.NICKNAME_ALREADY_EXISTS,
+                            description = "이미 사용 중인 닉네임입니다."
+                    ),
+                    @SwaggerApiFailedResponse(
+                            value = ExceptionType.MEMBER_NOT_FOUND,
+                            description = "존재하지 않는 사용자입니다."
+                    ),
+                    @SwaggerApiFailedResponse(
+                            value = ExceptionType.ACCESS_DENIED,
+                            description = "접근 권한이 없습니다."
+                    )
+            }
+    )
+    @PreAuthorize("hasAuthority('ROLE_USER')")
+    @PutMapping("/api/v1/members/my-profile")
+    ResponseEntity<ResponseBody<Void>> updateMyProfile(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = UpdateNicknameRequest.class),
+                            examples = @ExampleObject(
+                                    name = "닉네임 변경 예시",
+                                    value = """
+                                            { "nickname": "letsgu_user01" }
+                                            """
+                            )
+                    )
+            )
+            UpdateNicknameRequest updateNicknameRequest
     );
 }

--- a/src/main/java/avengers/lion/member/controller/MemberController.java
+++ b/src/main/java/avengers/lion/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package avengers.lion.member.controller;
 
 import avengers.lion.member.api.MemberApi;
 import avengers.lion.member.dto.UpdateNicknameRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import avengers.lion.global.response.ResponseBody;
 import avengers.lion.global.response.ResponseUtil;
@@ -26,6 +27,7 @@ public class MemberController implements MemberApi {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(memberService.getMyProfile(memberId)));
     }
     @PutMapping("/my-profile")
+    @PreAuthorize("hasAuthority('ROLE_USER')")
     public ResponseEntity<ResponseBody<Void>> updateMyProfile(@AuthenticationPrincipal Long memberId, @RequestBody UpdateNicknameRequest updateNicknameRequest) {
         memberService.updateNickname(memberId, updateNicknameRequest);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse());

--- a/src/main/java/avengers/lion/member/controller/MemberController.java
+++ b/src/main/java/avengers/lion/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package avengers.lion.member.controller;
 
 import avengers.lion.member.api.MemberApi;
+import avengers.lion.member.dto.UpdateNicknameRequest;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import avengers.lion.global.response.ResponseBody;
 import avengers.lion.global.response.ResponseUtil;
@@ -8,9 +9,7 @@ import avengers.lion.member.dto.MyProfileResponse;
 import avengers.lion.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,4 +25,10 @@ public class MemberController implements MemberApi {
     public ResponseEntity<ResponseBody<MyProfileResponse>> getMyProfile(@AuthenticationPrincipal Long memberId) {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(memberService.getMyProfile(memberId)));
     }
+    @PutMapping("/my-profile")
+    public ResponseEntity<ResponseBody<Void>> updateMyProfile(@AuthenticationPrincipal Long memberId, @RequestBody UpdateNicknameRequest updateNicknameRequest) {
+        memberService.updateNickname(memberId, updateNicknameRequest);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
 }
+

--- a/src/main/java/avengers/lion/member/domain/Member.java
+++ b/src/main/java/avengers/lion/member/domain/Member.java
@@ -64,4 +64,8 @@ public class Member extends BaseEntity {
             throw new BusinessException(ExceptionType.INSUFFICIENT_POINT);
         this.point-=price;
     }
+
+    public void updateNickname(String nickname){
+        this.nickname=nickname;
+    }
 }

--- a/src/main/java/avengers/lion/member/dto/UpdateNicknameRequest.java
+++ b/src/main/java/avengers/lion/member/dto/UpdateNicknameRequest.java
@@ -1,4 +1,11 @@
 package avengers.lion.member.dto;
 
-public record UpdateNicknameRequest(String nickname) {
+
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateNicknameRequest(
+        @Pattern(regexp = "^[a-z0-9]{1,10}$",
+                message = "닉네임은 영어 소문자와 숫자만 사용하며, 최대 10자까지 가능합니다.")
+        String nickname
+) {
 }

--- a/src/main/java/avengers/lion/member/dto/UpdateNicknameRequest.java
+++ b/src/main/java/avengers/lion/member/dto/UpdateNicknameRequest.java
@@ -1,0 +1,4 @@
+package avengers.lion.member.dto;
+
+public record UpdateNicknameRequest(String nickname) {
+}

--- a/src/main/java/avengers/lion/member/repository/MemberRepository.java
+++ b/src/main/java/avengers/lion/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/avengers/lion/member/repository/MemberRepository.java
+++ b/src/main/java/avengers/lion/member/repository/MemberRepository.java
@@ -11,5 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/avengers/lion/member/service/MemberService.java
+++ b/src/main/java/avengers/lion/member/service/MemberService.java
@@ -4,9 +4,11 @@ import avengers.lion.global.exception.BusinessException;
 import avengers.lion.global.exception.ExceptionType;
 import avengers.lion.member.domain.Member;
 import avengers.lion.member.dto.MyProfileResponse;
+import avengers.lion.member.dto.UpdateNicknameRequest;
 import avengers.lion.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,5 +32,15 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(()-> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
         return member.getPoint();
+    }
+
+    @Transactional
+    public void updateNickname(Long memberId, UpdateNicknameRequest request){
+        String nickname = request.nickname();
+        if(memberRepository.existsByNickname(nickname))
+            throw new BusinessException(ExceptionType.NICKNAME_ALREADY_EXISTS);
+        Member member = memberRepository.findById(memberId)
+                        .orElseThrow(()-> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
+        member.updateNickname(nickname);
     }
 }

--- a/src/main/java/avengers/lion/member/service/MemberService.java
+++ b/src/main/java/avengers/lion/member/service/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
     @Transactional
     public void updateNickname(Long memberId, UpdateNicknameRequest request){
         String nickname = request.nickname();
-        if(memberRepository.existsByNickname(nickname))
+        if(memberRepository.existsByNicknameAndIdNot(nickname, memberId))
             throw new BusinessException(ExceptionType.NICKNAME_ALREADY_EXISTS);
         Member member = memberRepository.findById(memberId)
                         .orElseThrow(()-> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));


### PR DESCRIPTION
## What is this PR?🔍

- 랜덤 프로필 이미지 & 마이페이지 닉네임 변경 기능

## Changes💻

-  가입 시 랜덤 프로필 이미지를 구현했습니다. 사전에 Cloudinary에 이미지를 업로드 하고, 주소를 받아와서 random 라이브러리를 통해 가입 시 랜덤 이미지를 배정합니다.
- 마이페이지 내에서 닉네임을 변경할 수 있는 api를 개발했습니다. 이때 중복 닉네임 예외 처리를 처리하였습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 마이프로필 닉네임 수정 기능 추가(로그인 필요). 닉네임 중복 시 충돌 오류를 반환합니다.
  - 회원가입 시 프로필 이미지가 랜덤으로 자동 지정되어 별도 URL 입력 없이 가입 가능합니다.
- Documentation
  - 회원가입 요청 항목에서 프로필 이미지 URL 제거로 문서 업데이트.
  - 마이프로필 조회/수정 API 문서 개선: 태그 설명 변경, 오류 사례 및 예제 요청/응답 추가, 접근 권한 안내 수정, 포인트 정보 포함 안내.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->