### PR TITLE
feat : fast api 연결 설정

### DIFF
--- a/src/main/java/avengers/lion/mission/dto/VerificationEventType.java
+++ b/src/main/java/avengers/lion/mission/dto/VerificationEventType.java
@@ -1,9 +1,22 @@
 package avengers.lion.mission.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum VerificationEventType {
     STARTED,     // 분석 시작
     PROGRESS,    // 진행률 업데이트
     COMPLETED,   // 성공적으로 완료
     FAILED,      // 분석 실패
-    ERROR        // 시스템 오류
+    ERROR;        // 시스템 오류
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static VerificationEventType of(String value) {
+        if(value == null) return null;
+        return VerificationEventType.valueOf(value.toUpperCase());
+    }
+    @JsonValue
+    public String toValue() {
+        return name().toLowerCase();
+    }
 }

--- a/src/main/java/avengers/lion/mission/dto/request/FastApiCallbackRequest.java
+++ b/src/main/java/avengers/lion/mission/dto/request/FastApiCallbackRequest.java
@@ -1,13 +1,13 @@
 package avengers.lion.mission.dto.request;
 
+import avengers.lion.mission.dto.VerificationEventType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /*
 Fast Api로부터 받아오는 dto
  */
 public record FastApiCallbackRequest(
-    @JsonProperty("job_id") String jobId,
-    @JsonProperty("event_type") String eventType,  // "progress" | "completed" | "failed"
-    Boolean verified    // 인증 성공 여부// 성공/실패 사유
+        @JsonProperty("job_id") String jobId,
+        @JsonProperty("event_type") VerificationEventType eventType  // "progress" | "completed" | "failed"
 ) {
 }

--- a/src/main/java/avengers/lion/mission/service/CallbackService.java
+++ b/src/main/java/avengers/lion/mission/service/CallbackService.java
@@ -2,6 +2,7 @@ package avengers.lion.mission.service;
 
 import avengers.lion.global.exception.BusinessException;
 import avengers.lion.global.exception.ExceptionType;
+import avengers.lion.mission.dto.VerificationEventType;
 import avengers.lion.mission.dto.request.FastApiCallbackRequest;
 import avengers.lion.mission.dto.VerificationEvent;
 import avengers.lion.mission.domain.CompletedMission;
@@ -93,9 +94,9 @@ public class CallbackService {
     public void processCallback(String jobId, FastApiCallbackRequest request) {
         try {
             switch (request.eventType()) {
-                case "progress" -> handleProgressCallback(jobId);
-                case "completed" -> handleCompletedCallback(jobId, request);
-                case "failed" -> handleFailedCallback(jobId, request);
+                case VerificationEventType.PROGRESS -> handleProgressCallback(jobId);
+                case VerificationEventType.COMPLETED -> handleCompletedCallback(jobId, request);
+                case VerificationEventType.FAILED -> handleFailedCallback(jobId, request);
                 default -> {
                     eventService.sendEvent(jobId, VerificationEvent.error(jobId));
                 }
@@ -124,7 +125,7 @@ public class CallbackService {
             return;
         }
 
-        boolean verified = request.verified() != null ? request.verified() : false;
+        boolean verified = request.eventType().equals(VerificationEventType.COMPLETED);
 
         if (verified) {
             // 인증 성공 시 DB에 저장 (이미지는 이미 Cloudinary에 업로드됨)

--- a/src/main/java/avengers/lion/mission/service/CallbackService.java
+++ b/src/main/java/avengers/lion/mission/service/CallbackService.java
@@ -94,9 +94,9 @@ public class CallbackService {
     public void processCallback(String jobId, FastApiCallbackRequest request) {
         try {
             switch (request.eventType()) {
-                case VerificationEventType.PROGRESS -> handleProgressCallback(jobId);
-                case VerificationEventType.COMPLETED -> handleCompletedCallback(jobId, request);
-                case VerificationEventType.FAILED -> handleFailedCallback(jobId, request);
+                case PROGRESS -> handleProgressCallback(jobId);
+                case COMPLETED -> handleCompletedCallback(jobId, request);
+                case FAILED -> handleFailedCallback(jobId, request);
                 default -> {
                     eventService.sendEvent(jobId, VerificationEvent.error(jobId));
                 }

--- a/src/main/java/avengers/lion/mission/service/MissionVerifyService.java
+++ b/src/main/java/avengers/lion/mission/service/MissionVerifyService.java
@@ -24,7 +24,7 @@ public class MissionVerifyService {
     @Value("${app.fast-api.url}")
     private String fastApiUrl;
 
-    @Value("${app.public-base-url")
+    @Value("${app.public-base-url}")
     private String publicBaseUrl;
 
     /*

--- a/src/main/java/avengers/lion/mission/service/MissionVerifyService.java
+++ b/src/main/java/avengers/lion/mission/service/MissionVerifyService.java
@@ -21,8 +21,11 @@ public class MissionVerifyService {
     private final VerificationCleanupService cleanupService;
     private final WebClient webClient;
     
-    @Value("${app.fastapi-url:http://localhost:8080/mock-fastapi}")
+    @Value("${app.fast-api.url}")
     private String fastApiUrl;
+
+    @Value("${app.public-base-url")
+    private String publicBaseUrl;
 
     /*
     1단계: 이미지 업로드용 Pre-signed URL 생성
@@ -86,8 +89,7 @@ public class MissionVerifyService {
         }
     }
     
-    @Value("${app.public-base-url:http://localhost:8080}")
-    private String publicBaseUrl;
+
 
     @Async
     public void callFastApiAsync(String jobId, String imageUrl) {


### PR DESCRIPTION
## What is this PR?🔍

- fast api 통신 설정

## Changes💻

-  fast api uri 설정
-  인증 통신 값 Enum 설정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 이벤트 타입을 문자열에서 enum으로 전환해 콜백 처리 로직을 타입 안전하게 개선했습니다. FastApiCallbackRequest의 verified 필드를 제거했으며 외부 동작에는 변화가 없습니다.
- **Chores**
  - 서브모듈 포인터를 최신 커밋으로 업데이트했습니다.
  - 환경설정 키를 정리하여 app.fast-api.url 및 app.public-base-url를 사용하도록 변경했고 기본 localhost 값은 제거되었습니다. 배포 시 두 값을 반드시 설정해야 하며 콜백 URL은 public-base-url을 기준으로 생성됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->