### PR TITLE
chore : cors 설정

### DIFF
--- a/src/main/java/avengers/lion/global/config/CorsConfig.java
+++ b/src/main/java/avengers/lion/global/config/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry){
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173","http://localhost:3000")
+                .allowedOrigins("http://localhost:5173","http://localhost:3000", "https://lets-gu-front-end.vercel.app")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization", "Cache-Control", "Content-Type")


### PR DESCRIPTION
## What is this PR?🔍

- 프론트 배포 url cors 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 프런트엔드 배포 도메인(https://lets-gu-front-end.vercel.app)을 CORS 허용 오리진에 추가했습니다. 기존 로컬 개발 도메인 허용은 유지되며, 기타 CORS 설정은 변경 없습니다.
* Bug Fixes
  * 배포 환경에서 특정 도메인 접속 시 발생하던 CORS 차단 문제를 해소했습니다. 이제 해당 도메인에서의 브라우저 요청(로그인/데이터 조회 등)이 안정적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->