### PR TITLE
test

### DIFF
--- a/src/main/java/avengers/lion/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/avengers/lion/review/repository/ReviewQueryRepositoryImpl.java
@@ -50,7 +50,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository{
         BooleanBuilder where = new BooleanBuilder()
                 .and(r.member.id.eq(memberId));
         if (cursorId != null) {
-            where.and(sortType.equals(SortType.ASC) ? r.id.lt(cursorId) : r.id.gt(cursorId));
+            where.and(sortType.equals(SortType.ASC) ? r.id.gt(cursorId) : r.id.lt(cursorId));
         }
         OrderSpecifier<?> orderSpecifier = sortType.equals(SortType.ASC) ? r.id.asc() : r.id.desc();
         QCompletedMission cm = QCompletedMission.completedMission;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 작성한 리뷰 목록에서 정렬(오름/내림차순) 선택 시 다음/이전 페이지 이동 방향이 비일관적이던 문제를 수정했습니다. 이제 커서 기반 페이지네이션에서 “더보기” 또는 스크롤 로드 시 항목이 올바른 순서로 이어지며, 누락되거나 중복 노출되는 현상이 방지됩니다. 정렬 기준에 따라 목록 연결이 자연스럽게 이어져 기대한 순서로 리뷰를 탐색할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->